### PR TITLE
Use a `list_sizes_unnamed()` helper to avoid retaining dim names

### DIFF
--- a/R/broadcast.R
+++ b/R/broadcast.R
@@ -35,7 +35,7 @@ broadcast.default <- function(x, dim_names, ...) {
       is_dim_names(dim_names)
     )
 
-    dim <- list_sizes(dim_names)
+    dim <- list_sizes_unnamed(dim_names)
     x <- array(vec_recycle(x, prod(dim)),
                dim = dim)
 
@@ -104,7 +104,7 @@ broadcast_dim_names <- function(old_dim_names, new_dim_names) {
     } else {
       # Set dimensions
       new_dim <- vec_rep(1, vec_size(new_axes))
-      new_dim[new_axes %in% old_axes] <- list_sizes(old_dim_names)
+      new_dim[new_axes %in% old_axes] <- list_sizes_unnamed(old_dim_names)
 
       # Subsetting
       old_dim_names <- old_dim_names[new_axes]

--- a/R/dibble.R
+++ b/R/dibble.R
@@ -117,7 +117,7 @@ as_dibble.rowwise_df <- function(x, ...) {
   )
 
   dim_names <- lapply(haystack, vec_unique)
-  dim <- list_sizes(dim_names)
+  dim <- list_sizes_unnamed(dim_names)
 
   needles <- expand.grid(dim_names,
                          KEEP.OUT.ATTRS = FALSE,
@@ -214,7 +214,7 @@ dimnames_dibble <- function(x) {
 }
 
 dim_dibble <- function(x) {
-  list_sizes(dimnames(x))
+  list_sizes_unnamed(dimnames(x))
 }
 
 as_tibble_dibble <- function(x, ..., n) {
@@ -412,7 +412,7 @@ rename_dibble <- function(.data, ...) {
 print_dibble <- function(x, n, ...) {
   dim_names <- dimnames(x)
   axes <- names(dim_names)
-  dim <- list_sizes(dim_names)
+  dim <- list_sizes_unnamed(dim_names)
   size_dim <- prod(dim)
 
   meas_names <- colnames(x)
@@ -439,7 +439,7 @@ print_dibble <- function(x, n, ...) {
 
     if (is_grouped_ddf(x)) {
       group_dim_names <- group_keys(x)
-      size_groups <- big_mark(prod(list_sizes(group_dim_names)))
+      size_groups <- big_mark(prod(list_sizes_unnamed(group_dim_names)))
       tbl_sum <- c(tbl_sum,
                    Groups = paste0(commas(names(group_dim_names)), " [", size_groups, "]"))
     }

--- a/R/grouped_ddf.R
+++ b/R/grouped_ddf.R
@@ -25,7 +25,7 @@ group_vars.grouped_ddf <- function(x) {
 group_by.tbl_ddf <- function(.data, ...) {
   dim_names <- dimnames(.data)
   axes <- names(dim_names)
-  dim <- list_sizes(dim_names)
+  dim <- list_sizes_unnamed(dim_names)
   size <- prod(dim)
 
   loc <- tidyselect::eval_select(expr(c(...)), dim_names)
@@ -35,7 +35,7 @@ group_by.tbl_ddf <- function(.data, ...) {
   )
 
   group_dim_names <- dim_names[loc]
-  group_dim <- list_sizes(group_dim_names)
+  group_dim <- list_sizes_unnamed(group_dim_names)
 
   dim_names <- dim_names[-loc]
   dim <- dim[-loc]
@@ -57,7 +57,7 @@ group_by.tbl_ddf <- function(.data, ...) {
 ungroup.grouped_ddf <- function(x, ...) {
   dim_names <- dimnames(x)
   axes <- names(dim_names)
-  dim <- list_sizes(dim_names)
+  dim <- list_sizes_unnamed(dim_names)
 
   group_axes <- group_vars(x)
 
@@ -181,7 +181,7 @@ mutate.grouped_ddf <- function(.data, ...) {
   seq_nms <- seq_along(nms)
 
   group_dim_names <- group_keys(.data)
-  group_dim <- list_sizes(group_dim_names)
+  group_dim <- list_sizes_unnamed(group_dim_names)
   size <- prod(group_dim)
 
   .data <- undibble(.data)
@@ -210,7 +210,7 @@ mutate.grouped_ddf <- function(.data, ...) {
 #' @export
 summarise.grouped_ddf <- function(.data, ...) {
   dim_names <- group_keys(.data)
-  dim <- list_sizes(dim_names)
+  dim <- list_sizes_unnamed(dim_names)
   size <- prod(dim)
 
   dots <- enquos(..., .named = TRUE)

--- a/R/utils.R
+++ b/R/utils.R
@@ -28,3 +28,7 @@ wrap_ddf_col <- function(f) {
     new_ddf_col(x, dim_names)
   }
 }
+
+list_sizes_unnamed <- function(x) {
+  unname(list_sizes(x))
+}


### PR DESCRIPTION
Hi @UchidaMizuki,

We are planning to release the next version of vctrs fairly soon, and your package was flagged in our revdeps.

In https://github.com/r-lib/vctrs/pull/1440, we changed `list_sizes(x)` to always retain the names of `x` on the resulting integer vector. This matches the behavior of `lengths()`.

You seem to call `list_sizes()` on the dimension names list, which means that it now retains the axis names on the resulting `dim` integer vector. I think you probably _don't_ want this, as many times you hand off to `as.array()` or build an array somehow, and the `dim =` argument to `array()` doesn't expect that dim vector to be named.

I've added a `list_sizes_unnamed()` helper and used it where it made sense to avoid this issue.

If you could please merge this and send a patch release of dibble to CRAN, we would greatly appreciate that as it would allow us to easily send a vctrs release out. Thanks!