### PR TITLE
Fix for dev purrr

### DIFF
--- a/R/broadcast.R
+++ b/R/broadcast.R
@@ -169,16 +169,20 @@ broadcast_dim_names_message <- function(old_dim_names, new_dim_names, brdcst) {
       message <- paste0("New axes, dim_names = ", new_axes_code)
     }
 
-    new_coords <- purrr::map2(new_dim_names, brdcst$loc,
-                              function(new_dim_name, loc) {
-                                loc <- is.na(loc)
+    if (is.null(brdcst$loc)) {
+      new_coords <- list()
+    } else {
+      new_coords <- purrr::map2(new_dim_names, brdcst$loc,
+                                function(new_dim_name, loc) {
+                                  loc <- is.na(loc)
 
-                                if (any(loc)) {
-                                  vec_slice(new_dim_name, loc)
-                                } else {
-                                  NULL
-                                }
-                              })
+                                  if (any(loc)) {
+                                    vec_slice(new_dim_name, loc)
+                                  } else {
+                                    NULL
+                                  }
+                                })
+    }
     loc_null <- purrr::map_lgl(new_coords, is.null)
     new_coords <- new_coords[!loc_null]
 


### PR DESCRIPTION
`map2()` now use the tidyverse recycling rules which means that 0-length inputs now partake in the recycling process (rather than immediately causing the function to return a 0-length output).