### PR TITLE
Fix for purrr 1.0.4

### DIFF
--- a/R/dim_names.R
+++ b/R/dim_names.R
@@ -69,10 +69,11 @@ union_dim_names <- function(x) {
 }
 
 intersect_dim_names <- function(x) {
-  purrr::modify(purrr::list_transpose(x, simplify = FALSE),
-                function(x) {
-                  purrr::reduce(x, set_intersect)
-                })
+  names <- purrr::map(x, names)
+  common_names <- purrr::reduce(names, set_intersect)
+
+  tr <- purrr::list_transpose(x, simplify = FALSE, template = common_names)
+  purrr::modify(tr, function(x) purrr::reduce(x, set_intersect))
 }
 
 diff_dim_names <- function(x) {


### PR DESCRIPTION
By default, `list_transpose()` now includes inspects all elements to determine the template, rather than just the first element. I've made what I think is the minimal fix: figure out what the common names are, and then use that as the template.